### PR TITLE
Restyle SIM with gruvbox theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,12 +1,45 @@
 body {
-    font-family: Arial, sans-serif;
-    padding: 20px;
+    font-family: Verdana, Geneva, sans-serif;
+    font-size: 10pt;
+    color: #ebdbb2; /* gruvbox fg */
+    background: #282828; /* gruvbox bg */
+    margin: 0;
+    padding: 0;
+}
+
+h1 {
+    background: #3c3836; /* gruvbox dark1 */
+    color: #ebdbb2;
+    font-weight: normal;
+    font-size: 16px;
+    padding: 3px 6px;
+    margin: 0 0 10px 0;
+}
+
+h1 button {
+    background: #ebdbb2;
+    color: #282828;
+    border: 1px solid #fe8019;
+    margin-left: 8px;
+    cursor: pointer;
+}
+
+a:link {
+    color: #fabd2f; /* gruvbox yellow */
+    text-decoration: none;
+}
+
+a:visited {
+    color: #d3869b; /* gruvbox purple */
+    text-decoration: none;
 }
 
 
 #main {
     display: flex;
     height: calc(100vh - 60px);
+    width: 100%;
+    margin: 0;
 }
 
 #inbox {
@@ -27,10 +60,10 @@ body {
 }
 
 .card {
-    border: 1px solid #ccc;
+    border: 1px solid #fe8019; /* gruvbox orange */
     padding: 10px;
     margin-bottom: 10px;
-    background: #fff;
+    background: #3c3836;
     cursor: pointer;
 
 }
@@ -56,7 +89,8 @@ body {
 }
 
 .overlay-content {
-    background: #fff;
+    background: #282828;
+    color: #ebdbb2;
     padding: 20px;
     width: 300px;
 }


### PR DESCRIPTION
## Summary
- switch to gruvbox colors
- remove left padding so cards align flush to the edge

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686187647750833183f8f3b066b5f235