### PR TITLE
Remove redundant move buttons

### DIFF
--- a/script.js
+++ b/script.js
@@ -80,46 +80,11 @@ function renderCards() {
         cardDiv.appendChild(descEl);
 
 
-        const upBtn = document.createElement('button');
-        upBtn.textContent = 'Move Up';
-        upBtn.disabled = index === 0;
-        upBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-
-            if (index > 0) {
-                const selected = selectedCard;
-                [cards[index], cards[index - 1]] = [cards[index - 1], cards[index]];
-                renderCards();
-                if (selected) {
-                    const newIndex = cards.indexOf(selected);
-                    if (newIndex !== -1) {
-                        showCardDetails(newIndex);
-                    }
-                }
-            }
-        });
-        cardDiv.appendChild(upBtn);
-
-        const downBtn = document.createElement('button');
-        downBtn.textContent = 'Move Down';
-        downBtn.disabled = index === cards.length - 1;
-
-        downBtn.addEventListener('click', (e) => {
-            e.stopPropagation();
-
-            if (index < cards.length - 1) {
-                const selected = selectedCard;
-                [cards[index], cards[index + 1]] = [cards[index + 1], cards[index]];
-                renderCards();
-                if (selected) {
-                    const newIndex = cards.indexOf(selected);
-                    if (newIndex !== -1) {
-                        showCardDetails(newIndex);
-                    }
-                }
-            }
-        });
-        cardDiv.appendChild(downBtn);
+        /*
+         * The UI previously included "Move Up" and "Move Down" buttons for
+         * reordering cards. Since drag-and-drop support has been implemented
+         * these controls are redundant and have been removed (issue #9).
+         */
 
         inbox.appendChild(cardDiv);
     });

--- a/style.css
+++ b/style.css
@@ -95,9 +95,6 @@ a:visited {
 
 }
 
-.card button {
-    margin-right: 5px;
-}
 
 #overlay {
     position: fixed;


### PR DESCRIPTION
## Summary
- delete the Move Up/Down buttons from each card and leave drag and drop as the way to reorder cards
- drop `.card button` styling which is no longer used

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68618b6427288331847fbb3489e35aa9