### PR TITLE
Fix issue 27: enter key now submits

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "This is a very small issue management system implemented with plain HTML, CSS and JavaScript.",
   "main": "script.js",
   "scripts": {
-    "test": "node test/search-bar.test.js"
+    "test": "node test/search-bar.test.js && node test/enter-key.test.js"
   },
   "keywords": [],
   "author": "",

--- a/script.js
+++ b/script.js
@@ -28,6 +28,14 @@ searchInput.addEventListener('input', () => {
     renderCards();
 });
 
+// Allow pressing Enter in the search field to trigger the search
+searchInput.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') {
+        e.preventDefault();
+        renderCards();
+    }
+});
+
 function saveCards() {
     localStorage.setItem('cards', JSON.stringify(cards));
 }
@@ -178,6 +186,13 @@ function showCardDetails(index) {
             saveCards();
             commentInput.value = '';
             showCardDetails(index);
+        }
+    });
+    // Pressing Enter (without Shift) should submit the comment
+    commentInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            addCommentBtn.click();
         }
     });
     readingPane.appendChild(addCommentBtn);

--- a/test/enter-key.test.js
+++ b/test/enter-key.test.js
@@ -1,0 +1,44 @@
+const fs = require('fs');
+const vm = require('vm');
+const { JSDOM } = require('jsdom');
+
+// helper to load DOM with script executed
+function loadApp(initialCards) {
+  const html = fs.readFileSync('index.html', 'utf8');
+  const dom = new JSDOM(html, { runScripts: 'outside-only', url: 'http://localhost' });
+  dom.window.localStorage.setItem('cards', JSON.stringify(initialCards));
+  const script = fs.readFileSync('script.js', 'utf8');
+  const context = dom.getInternalVMContext();
+  vm.runInContext(script, context);
+  return dom;
+}
+
+// test Enter key in search input triggers search
+(function() {
+  const dom = loadApp([
+    { title: 'First', description: '', comments: [] },
+    { title: 'Second', description: '', comments: [] },
+  ]);
+  const searchInput = dom.window.document.getElementById('searchInput');
+  const inbox = dom.window.document.getElementById('inbox');
+  searchInput.value = 'Second';
+  searchInput.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Enter' }));
+  if (inbox.children.length !== 1 || !inbox.textContent.includes('Second')) {
+    throw new Error('enter on search did not filter cards');
+  }
+})();
+
+// test Enter key in comment input adds comment
+(function() {
+  const dom = loadApp([{ title: 'Card', description: '', comments: [] }]);
+  dom.window.showCardDetails(0);
+  const textarea = dom.window.document.querySelector('.comment-input');
+  textarea.value = 'hello';
+  textarea.dispatchEvent(new dom.window.KeyboardEvent('keydown', { key: 'Enter' }));
+  const cards = JSON.parse(dom.window.localStorage.getItem('cards'));
+  if (cards[0].comments.length !== 1 || cards[0].comments[0].text !== 'hello') {
+    throw new Error('enter on comment input did not add comment');
+  }
+})();
+
+console.log('test passed');


### PR DESCRIPTION
## Summary
- trigger search when pressing enter in search input
- allow enter to submit a comment
- add tests covering the new behaviour
- run both tests with npm test

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686197cdeca48331a6cfd789be695c3b